### PR TITLE
For change in RTM2.0

### DIFF
--- a/wasanbon/core/plugins/admin/environment_plugin/settings/ubuntu/bashrc
+++ b/wasanbon/core/plugins/admin/environment_plugin/settings/ubuntu/bashrc
@@ -1,9 +1,9 @@
-source /usr/local/lib/python3.8/dist-packages/rtshell/data/shell_support
+#source /usr/local/lib/python3.8/dist-packages/rtshell/data/shell_support
 #export PKG_CONFIG_PATH=/usr/local/lib/pkgconfig:/opt/local/lib/pkgconfig:$PKG_CONFIG_PATH
-export RTM_ROOT=/usr/include/openrtm-1.2
+export RTM_ROOT=/usr/include/openrtm-2.0
 #export PYTHONPATH=/usr/local/lib/python3.8/dist-packages:$PYTHONPATH
 #export CMAKE_PREFIX_PATH=/opt/local/lib/cmake:/usr/local/lib/cmake:$CMAKE_PREFIX_PATH
-export RTM_JAVA_ROOT=/usr/lib/x86_64-linux-gnu/openrtm-1.2/
+export RTM_JAVA_ROOT=/usr/lib/x86_64-linux-gnu/openrtm-2.0
 
 wasanbon-cd() {
   if [ ${#} -eq 0 ]; then

--- a/wasanbon/core/plugins/admin/environment_plugin/settings/ubuntu/hints.yaml
+++ b/wasanbon/core/plugins/admin/environment_plugin/settings/ubuntu/hints.yaml
@@ -35,3 +35,4 @@ eclipse :
   - "/usr/local/bin/openrtp"
   - "/usr/bin/openrtp"
   - "/usr/share/openrtp"
+  - "/usr/bin/openrtp2"

--- a/wasanbon/core/plugins/admin/systemlauncher_plugin/run.py
+++ b/wasanbon/core/plugins/admin/systemlauncher_plugin/run.py
@@ -46,7 +46,7 @@ def start_cpp_rtcd(filepath, verbose=True):
     args['stdin'] = None if verbose else subprocess.PIPE
     if sys.platform == 'win32':
         args['creationflags'] = 512
-    cmd = ['rtcd', '-f', filepath]
+    cmd = ['rtcd2', '-f', filepath]
     return subprocess.Popen(cmd, **args)
 
 


### PR DESCRIPTION
Several command names are changed in OpenRTM-aist-2.0.0(RTM2.0) to satisfy the co-existence with OpenRTM-aist-1.X.X.
When we want to use the wasanbon by RTM2.0, the changed command should be found by the wasanbon.
Thus, I modified the file to find the openrtp2 in the initial setup process of wasanbon.